### PR TITLE
Use a different ID for the Run on brick button

### DIFF
--- a/core/rob_controls.js
+++ b/core/rob_controls.js
@@ -180,7 +180,7 @@ Blockly.RobControls.prototype.createDom = function() {
   var control = this;  
   this.svgGroup_ = Blockly.createSvgElement('g', {'class': 'blocklyButtons'}, null);
   this.runOnBrick = this.createButton_(this.PATH_RUNONBRICK_, 0, 0, Blockly.Msg.MENU_START_BRICK);
-  this.runOnBrick.setAttribute("id", "runInSim");
+  this.runOnBrick.setAttribute("id", "runOnBrick");
   this.runInSim = this.createButton_(this.PATH_RUNINSIM_, 1, 0, Blockly.Msg.MENU_START_SIM);
   this.simStop = this.createButton_(this.PATH_SIMSTOP_, 1, 0, Blockly.Msg.MENU_SIM_STOP);
 //  this.simStep = this.createButton_(this.PATH_SIMSTEP_, 1, 1);


### PR DESCRIPTION
Before, the `Run on Brick` and `Run in Sim` buttons had the same ID. I don't think these IDs are used anywhere so this should be a harmless cleanup.
