### PR TITLE
OpenRobrtaLab-Issue:#1597 SpikePrime : Animation breaks program 

### DIFF
--- a/blocks/actions.js
+++ b/blocks/actions.js
@@ -1280,7 +1280,7 @@ Blockly.Blocks['actions_display_image'] = {
             }, {
                 type: 'input_value',
                 name: 'VALUE',
-                check: 'Image'
+                check: ["Image","Array_Image"]
             }],
             colour: Blockly.CAT_ACTION_RGB,
             previousStatement: true,


### PR DESCRIPTION
Check for actions_display_image didn't whitelist Array_Image